### PR TITLE
Fix JS syntax in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ npm install --save-dev gulp-fontgen
 Then, add it to your `gulpfile.js`:
 
 ```javascript
-var gulp-fontgen = require("gulp-fontgen");
+var fontgen = require("gulp-fontgen");
 
 gulp.src("./src/*.ext")
-    .pipe(gulp-fontgen({
+    .pipe(fontgen({
         dest: "./dest/"
     }))
 ```


### PR DESCRIPTION
JavaScript would treat `-` in `var gulp-fontgen(...)` as a minus sign, if `gulp` is defined in `gulpfile.js`, this would lead to `fontgen is not defined` error.