### PR TITLE
Updated fontfacegen version to 0.1.9 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "css"
   ],
   "dependencies": {
-    "fontfacegen": "^0.1.7",
+    "fontfacegen": "^0.1.9",
     "gulp-util": "^3.0.7",
     "through2": "^2.0.0"
   },


### PR DESCRIPTION
Assuming [#18](https://github.com/agentk/fontfacegen/pull/18] is merged and published  this package needs its fontfacegen version to be updated to 0.1.9